### PR TITLE
feat(schema): add log and ptc price dataframes

### DIFF
--- a/src/portfolio_analyzer/data/schema.py
+++ b/src/portfolio_analyzer/data/schema.py
@@ -2,6 +2,7 @@ import re
 from datetime import datetime
 from typing import Annotated
 
+import numpy as np
 import pandas as pd
 import pandera.pandas as pa
 from pydantic import AfterValidator, BaseModel, ConfigDict, Field
@@ -121,6 +122,14 @@ class PriceHistory(BaseModel):
     @property
     def assets(self) -> list[str]:
         return self.prices.columns.tolist()
+
+    @property
+    def pct_change_returns(self) -> pd.DataFrame:
+        return self.prices.pct_change().dropna(how="all")
+
+    @property
+    def log_returns(self) -> pd.DataFrame:
+        return (self.pct_change_returns + 1).apply(np.log)
 
 
 class SymbolInfo(BaseModel):

--- a/tests/data/test_schema.py
+++ b/tests/data/test_schema.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import numpy as np
 import pandas as pd
 import pandera.errors as pe
 import pytest
@@ -104,3 +105,29 @@ def test_pricehistory_pydantic_model_validation():
             end_date=datetime(2020, 1, 3),
             frequency="D",
         )
+
+
+def test_pricehistory_pydantic_model_pct_change_returns():
+    """Test the pct_change_returns property of PriceHistory."""
+    prices = _make_price_df()
+    ph = PriceHistory(
+        prices=prices,
+        start_date=datetime(2020, 1, 1),
+        end_date=datetime(2020, 1, 3),
+        frequency="D",
+    )
+    expected_pct_changes = prices.pct_change().dropna(how="all")
+    pd.testing.assert_frame_equal(ph.pct_change_returns, expected_pct_changes)
+
+
+def test_pricehistory_pydantic_model_log_returns():
+    """Test the log_returns property of PriceHistory."""
+    prices = _make_price_df()
+    ph = PriceHistory(
+        prices=prices,
+        start_date=datetime(2020, 1, 1),
+        end_date=datetime(2020, 1, 3),
+        frequency="D",
+    )
+    expected_log_returns = (prices.pct_change().dropna(how="all") + 1).apply(np.log)
+    pd.testing.assert_frame_equal(ph.log_returns, expected_log_returns)


### PR DESCRIPTION
Added ptc and log dataframes as properties to the PriceHistory model. Check commits for more info.